### PR TITLE
Fix to handle dateFormat paramater and minor fix at the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Any `template.hbs`, you should pass all the `paper-input` options and `flatpickr
             @altInput={{true}}
             @appendDataInput={{false}}
             @classNames={{classString}}
-            @format="MMMM D, YYYY"
+            @altFormat="MMMM D, YYYY"
+            @dateFormat="Y-m-d"
             @value={{readonly dateSelected}}
             @required={{true}}
             @enableTime={{false}}
@@ -52,7 +53,6 @@ Any `template.hbs`, you should pass all the `paper-input` options and `flatpickr
             @locale="es"
             @label="otherheyeh"
             @placeholder="Heyhey"
-            @enableTime={{true}}
         />
     </PaperFlatpickr>
 ```
@@ -66,7 +66,8 @@ If you don't care about `allowClear` you can just use the `paper-flatpickr-input
         @altInput={{true}}
         @appendDataInput={{false}}
         @classNames={{classString}}
-        @format="MMMM D, YYYY"
+        @altFormat="MMMM D, YYYY"
+        @dateFormat="Y-m-d"
         @value={{readonly dateSelected}}
         @required={{true}}
         @enableTime={{false}}
@@ -74,7 +75,6 @@ If you don't care about `allowClear` you can just use the `paper-flatpickr-input
         @locale="es"
         @label="otherheyeh"
         @placeholder="Heyhey"
-        @enableTime={{true}}
     />
 ```
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Any `template.hbs`, you should pass all the `paper-input` options and `flatpickr
 
 If you don't care about `allowClear` you can just use the `paper-flatpickr-input` directly
 
-``` 
-    <PaperFlatPickrInput
+```
+    <PaperFlatpickrInput
         @disableMobile={{true}}
         @allowInput={{false}}
         @altInput={{true}}

--- a/addon/components/paper-flatpickr-input.js
+++ b/addon/components/paper-flatpickr-input.js
@@ -104,6 +104,7 @@ export default PaperInput.extend(FlatpickrMixin, {
       });
     }
   ),
+
   _attributeHasChanged(changedAttrs, attr, callback) {
     if (changedAttrs && changedAttrs[attr]) {
       const [oldAttr, newAttr] = changedAttrs[attr];
@@ -114,7 +115,9 @@ export default PaperInput.extend(FlatpickrMixin, {
   },
 
   _onChange(selectedDates, dateStr, instance) {
-    //let handleInput emit onChange
+    if (this.onChange instanceof Function) {
+      invokeAction(this, "onChange", selectedDates, dateStr, instance);
+    }
   },
 
   _onOpen(selectedDates, dateStr, instance) {
@@ -122,6 +125,7 @@ export default PaperInput.extend(FlatpickrMixin, {
     this.set("isTouched", true);
     this.notifyValidityChange();
   },
+
   _onClose(selectedDates, dateStr, instance) {
     if (this.mode === "range" && selectedDates.length < 2) {
       invokeAction(this, "onChange", null);
@@ -141,8 +145,9 @@ export default PaperInput.extend(FlatpickrMixin, {
     },
 
     handleInput(e) {
+/*
       let flatpickr = this.field._flatpickr;
-      
+
       invokeAction(
         this,
         "onChange",
@@ -150,6 +155,7 @@ export default PaperInput.extend(FlatpickrMixin, {
         flatpickr.altInput.value || flatpickr.input.value,
         flatpickr
       );
+ */
       // setValue below ensures that the input value is the same as this.value
       run.next(() => {
         if (this.isDestroyed) {
@@ -166,6 +172,7 @@ export default PaperInput.extend(FlatpickrMixin, {
       this.notifyValidityChange();
     }
   },
+
   willDestroyElement() {
     this._super(...arguments);
     invokeAction(this, "unregisterInput");

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}


### PR DESCRIPTION
Hi @betocantu93 ,
I've a little change so that the addon can handle the dateFormat according to the custom callback when the user wants to get the date based on the dateFormat that they wanted.

As before, it was a return to the dateFormat as the same as the altFormat value; I think this could be different on showing at the UI (using the altFormat) and storing them to ember-data (using the dateFormat)...